### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This MCP server provides tools for AI assistants to:
 - Extract images from URLs
 - Process base64-encoded images
 
+<a href="https://glama.ai/mcp/servers/@ifmelate/mcp-image-extractor">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ifmelate/mcp-image-extractor/badge" alt="Image Extractor MCP server" />
+</a>
+
 How it looks in Cursor:
 
 <img width="687" alt="image" src="https://github.com/user-attachments/assets/8954dbbd-7e7a-4f27-82a7-b251bd3c5af2" />


### PR DESCRIPTION
This PR adds a badge for the [MCP Image Extractor](https://glama.ai/mcp/servers/@ifmelate/mcp-image-extractor) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ifmelate/mcp-image-extractor">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ifmelate/mcp-image-extractor/badge" alt="Image Extractor MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.